### PR TITLE
Fix unsupported type error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/spanner v1.27.0
 	github.com/goccy/go-yaml v1.9.4
 	github.com/google/go-cmp v0.5.6
+	google.golang.org/genproto v0.0.0-20211019152133-63b7e35f4404
 )
 
 require (
@@ -24,7 +25,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/api v0.58.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20211019152133-63b7e35f4404 // indirect
 	google.golang.org/grpc v1.40.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/internal/yaml/testdata/seeds/Foo.yaml
+++ b/internal/yaml/testdata/seeds/Foo.yaml
@@ -7,3 +7,7 @@
 
 - FooID: 'bcc0d0df-81bf-41b5-9427-9deb5e8f76f4'
   Name: foo3
+
+# Test for the integer value
+- FooID: 123
+  Name: foo4

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -58,7 +58,13 @@ func (l *Loader) Load(ctx context.Context, dir string) ([]*model.Table, error) {
 						return fmt.Errorf("failed to unmarshal yaml proparty: %w", err)
 					}
 
-					records[i].Values[key] = p.Value
+					// Spanner does not support the type uint64
+					val, ok := p.Value.(uint64)
+					if ok {
+						records[i].Values[key] = int64(val)
+					} else {
+						records[i].Values[key] = p.Value
+					}
 				}
 
 			}

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -123,6 +123,12 @@ func TestLoad(t *testing.T) {
 						"Name":  "foo3",
 					},
 				},
+				{
+					Values: map[string]interface{}{
+						"FooID": int64(123),
+						"Name":  "foo4",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
- Fix the `client doesn't support type uint64` error when we use an integer value in a YAML file.