### PR TITLE
yaml: add a test case for all data types

### DIFF
--- a/internal/spanner/testdata/schema.sql
+++ b/internal/spanner/testdata/schema.sql
@@ -24,3 +24,17 @@ CREATE TABLE Boo (
   Name STRING(MAX),
   CONSTRAINT FK_BooBaz FOREIGN KEY (BazID) REFERENCES Baz (BazID)
 ) PRIMARY KEY(BooID);
+
+CREATE TABLE AllTypes (
+  ID STRING(MAX) NOT NULL,
+  BoolValue BOOL,
+  Int64Value INT64,
+  Float64Value FLOAT64,
+  TimestampValue TIMESTAMP,
+  DateValue DATE,
+  StringValue STRING(MAX),
+  BytesValue BYTES(MAX),
+  NumericValue NUMERIC,
+  JSONValue JSON,
+  StringArray ARRAY<STRING(MAX)>,
+) PRIMARY KEY(ID);

--- a/internal/yaml/testdata/seeds/AllTypes.yaml
+++ b/internal/yaml/testdata/seeds/AllTypes.yaml
@@ -1,0 +1,16 @@
+---
+# Values are need to be encoded as documented.
+# https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.TypeCode
+- ID: "All_Type_Values"
+  BoolValue: true
+  BytesValue: "aG9nZQ==" # base64("hoge")
+  DateValue: "2022-04-01"
+  Float64Value: 3.14159
+  Int64Value: 42
+  JSONValue: '{"test": 1}'
+  NumericValue: "-12345678901234567890123456789.123456789"
+  StringValue: "FooBar"
+  TimestampValue: "2022-04-01T00:00:00Z"
+  # StringArray:
+  #   - "Foo"
+  #   - "Bar"

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -22,6 +22,26 @@ func TestLoad(t *testing.T) {
 
 	expected := []*model.Table{
 		{
+			Name: "AllTypes",
+			Records: []*model.Record{
+				{
+					Values: map[string]interface{}{
+						"DateValue":      "2022-04-01",
+						"Float64Value":   float64(3.14159),
+						"ID":             "All_Type_Values",
+						"Int64Value":     int64(42),
+						"JSONValue":      `{"test": 1}`,
+						"NumericValue":   string("-12345678901234567890123456789.123456789"),
+						"StringValue":    "FooBar",
+						"TimestampValue": "2022-04-01T00:00:00Z",
+						// "StringArray":    []interface{}{"Foo", "Bar"},
+						"BoolValue":  true,
+						"BytesValue": "aG9nZQ==",
+					},
+				},
+			},
+		},
+		{
 			Name: "Bar",
 			Records: []*model.Record{
 				{


### PR DESCRIPTION
This PR adds a test case for all Cloud Spanner data types.

* [x] `yaml.TestLoad`
* [x] `spanner.TestSave`

Note: `StringArray` is commented because `ARRAY` types are not supported(#13).